### PR TITLE
feat: Google Analytics 및 GTM 스크립트 추가, 프로덕션 환경에서만 로드되도록 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local'
 import './globals.css'
 import ConditionalLayout from '@/shared/components/ConditionalLayout'
 import MobileDetector from '@/shared/components/MobileDetector'
+import GoogleAnalytics from '@/shared/components/GoogleAnalytics'
 import Script from 'next/script'
 
 const pretendard = localFont({
@@ -23,12 +24,14 @@ export default function RootLayout({
 	children: React.ReactNode
 }>) {
 	const gtmId = process.env.NEXT_PUBLIC_GTM_ID
+	const gaId = process.env.NEXT_PUBLIC_GA_ID || 'G-M5WQ70GPZ7'
+	const isProduction = process.env.NODE_ENV === 'production'
 
 	return (
 		<html lang="ko" className={pretendard.variable} suppressHydrationWarning>
 			<head>
-				{/* DataLayer 초기화 */}
-				{gtmId && (
+				{/* DataLayer 초기화 - 프로덕션에서만 */}
+				{isProduction && (
 					<Script
 						id="gtm-datalayer"
 						strategy="beforeInteractive"
@@ -39,29 +42,55 @@ export default function RootLayout({
 				)}
 			</head>
 			<body className="font-pretendard min-h-screen">
-				{/* Google Tag Manager (noscript) */}
-				{gtmId && (
-					<noscript>
-						<iframe
-							src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
-							height="0"
-							width="0"
-							style={{ display: 'none', visibility: 'hidden' }}
+				{/* Google Tag Manager - 프로덕션에서만 로드 */}
+				{gtmId && isProduction && (
+					<>
+						<noscript>
+							<iframe
+								src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+								height="0"
+								width="0"
+								style={{ display: 'none', visibility: 'hidden' }}
+							/>
+						</noscript>
+						<Script
+							src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}`}
+							strategy="afterInteractive"
 						/>
-					</noscript>
+					</>
 				)}
 
-				{/* GTM 외부 스크립트 로드 */}
-				{gtmId && (
-					<Script
-						src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}`}
-						strategy="afterInteractive"
-					/>
+				{/* Google Analytics - 프로덕션에서만 로드 */}
+				{gaId && isProduction && (
+					<>
+						<Script
+							strategy="afterInteractive"
+							src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+						/>
+						<Script
+							id="gtag-init"
+							strategy="afterInteractive"
+							dangerouslySetInnerHTML={{
+								__html: `
+									window.dataLayer = window.dataLayer || [];
+									function gtag(){dataLayer.push(arguments);}
+									gtag('js', new Date());
+									gtag('config', '${gaId}', {
+										send_page_view: true,
+										debug_mode: false
+									});
+								`,
+							}}
+						/>
+					</>
 				)}
+
+				{/* Kakao SDK */}
+				<Script src="https://developers.kakao.com/sdk/js/kakao.js" strategy="afterInteractive" />
 
 				<MobileDetector />
+				{gaId && isProduction && <GoogleAnalytics gaId={gaId} />}
 				<ConditionalLayout>{children}</ConditionalLayout>
-				<script src="https://developers.kakao.com/sdk/js/kakao.js" async />
 			</body>
 		</html>
 	)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 	children: React.ReactNode
 }>) {
 	const gtmId = process.env.NEXT_PUBLIC_GTM_ID
-	const gaId = process.env.NEXT_PUBLIC_GA_ID || 'G-M5WQ70GPZ7'
+	const gaId = process.env.NEXT_PUBLIC_GA_ID
 	const isProduction = process.env.NODE_ENV === 'production'
 
 	return (

--- a/src/shared/components/GoogleAnalytics.tsx
+++ b/src/shared/components/GoogleAnalytics.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+interface GoogleAnalyticsProps {
+	gaId: string
+}
+
+export default function GoogleAnalytics({ gaId }: GoogleAnalyticsProps) {
+	const pathname = usePathname()
+
+	useEffect(() => {
+		if (typeof window === 'undefined' || !gaId || !window.gtag) return
+
+		// 페이지뷰 이벤트 전송
+		window.gtag('config', gaId, {
+			page_path: pathname,
+		})
+	}, [pathname, gaId])
+
+	return null
+}

--- a/src/shared/utils/gtm.ts
+++ b/src/shared/utils/gtm.ts
@@ -17,11 +17,78 @@ declare global {
 	}
 }
 
-export const trackEvent = (eventName: string, parameters: Record<string, GTMValue> = {}) => {
-	if (typeof window !== 'undefined' && window.dataLayer) {
+// 개발 환경 감지 함수
+const isLocalDevelopment = (): boolean => {
+	if (typeof window === 'undefined') return false
+
+	return (
+		window.location.hostname === 'localhost' ||
+		window.location.hostname === '127.0.0.1' ||
+		window.location.hostname.includes('.local')
+	)
+}
+
+// 프로덕션 환경 감지 함수
+const isProduction = (): boolean => {
+	return process.env.NODE_ENV === 'production'
+}
+
+// 개발 환경에서 로그를 출력하는 헬퍼 함수
+const logDevMessage = (service: 'GTM' | 'GA', action: string, data?: unknown): void => {
+	console.log(`%c[${service} DEV] ${action}`, 'color: #888;', data || '')
+}
+
+// GTM이 로드되었는지 확인하는 함수
+const isGTMLoaded = (): boolean => {
+	return (
+		typeof window !== 'undefined' && Array.isArray(window.dataLayer) && window.dataLayer.length > 0
+	)
+}
+
+// GTM 로드를 기다리는 함수
+const waitForGTM = (timeout = 5000): Promise<boolean> => {
+	return new Promise((resolve) => {
+		if (isGTMLoaded()) {
+			resolve(true)
+			return
+		}
+
+		const startTime = Date.now()
+		const checkInterval = setInterval(() => {
+			if (isGTMLoaded()) {
+				clearInterval(checkInterval)
+				resolve(true)
+			} else if (Date.now() - startTime > timeout) {
+				clearInterval(checkInterval)
+				resolve(false)
+			}
+		}, 100)
+	})
+}
+
+// GTM 이벤트 트래킹 함수
+const trackEvent = async (
+	eventName: string,
+	parameters: Record<string, GTMValue> = {},
+): Promise<void> => {
+	if (typeof window === 'undefined') return
+
+	// 개발 환경에서는 로그만 출력하고 실제 트래킹하지 않음
+	if (isLocalDevelopment()) {
+		logDevMessage('GTM', `이벤트 트래킹 비활성화: ${eventName}`, parameters)
+		return
+	}
+
+	// 프로덕션에서만 실제 트래킹
+	if (!isProduction()) return
+
+	const isLoaded = await waitForGTM()
+	if (isLoaded && window.dataLayer) {
 		window.dataLayer.push({
 			event: eventName,
 			...parameters,
 		})
 	}
 }
+
+export { trackEvent }


### PR DESCRIPTION
## 내용
### 상황
- 애널리틱스에서 활성자 수가 0에서 증가하지 않은 이슈가 있었습니다.
- 태그매니저에서 미리보기에서 정상적으로 태그 추가된것 확인되었으나 
- 실제로는 구글 애널리틱스로 데이터를 보내지 않고 있는 상태입니다.
### 해결
- 추가적으로 gtag('config') 호출이 필요한것으로 확인되어 스크립트 로직 수정되었습니다.
- 개발환경에서 활성자 수 증가한 것 확인되었으며 해당 이슈 에서 프로덕트 환경에서만 데이터 수집되도록 분기 처리 로직 작성되었습니다 .

### 문제 발생한 부분 
<img width="1168" height="73" alt="image" src="https://github.com/user-attachments/assets/1866ed0d-6c64-4536-8288-21a3b98c71ac" />
